### PR TITLE
9 MSVC Compatibility

### DIFF
--- a/src/cxx/Plugin/Reader/netCDFLFRicFile.cxx
+++ b/src/cxx/Plugin/Reader/netCDFLFRicFile.cxx
@@ -285,7 +285,7 @@ void netCDFLFRicFile::LoadVarDouble(const int varId,
 {
   // Check if number of dimensions matches netCDF variable
   const size_t numDims = this->GetVarNumDims(varId);
-  if (numDims != start.size() or numDims != count.size())
+  if (numDims != start.size() || numDims != count.size())
   {
     std::cerr << "netCDFLFRicFile::LoadVarDouble: number of dimensions does not match netCDF variable.\n";
   }
@@ -318,7 +318,7 @@ std::vector<double> netCDFLFRicFile::GetVarDouble(
 
   // Check if number of dimensions matches netCDF variable
   const size_t numDims = this->GetVarNumDims(varId);
-  if (numDims != start.size() or numDims != count.size())
+  if (numDims != start.size() || numDims != count.size())
   {
     std::cerr << "netCDFLFRicFile::GetVarDouble: number of dimensions does not match netCDF variable.\n";
     std::fill(varData.begin(), varData.end(), std::numeric_limits<double>::quiet_NaN());
@@ -352,7 +352,7 @@ std::vector<long long> netCDFLFRicFile::GetVarLongLong(
 
   // Check if number of dimensions matches netCDF variable
   const size_t numDims = this->GetVarNumDims(varId);
-  if (numDims != start.size() or numDims != count.size())
+  if (numDims != start.size() || numDims != count.size())
   {
     std::cerr << "netCDFLFRicFile::GetVarLongLong: number of dimensions does not match netCDF variable.\n";
     std::fill(varData.begin(), varData.end(), 0);
@@ -394,9 +394,9 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
         // Mesh descriptions in LFRic output files start with "Mesh2d"
         // and can be separate, or partially or fully unified
         // topology_dimension=2 means faces
-        if ((varName == "Mesh2d_full_levels" or
-             varName == "Mesh2d_face" or
-             (varName == "Mesh2d" and this->HasDim("full_levels"))) and
+        if ((varName == "Mesh2d_full_levels" ||
+             varName == "Mesh2d_face" ||
+             (varName == "Mesh2d" && this->HasDim("full_levels"))) &&
             this->GetAttInt(varId, "topology_dimension") == 2)
         {
           mesh2D.meshTopologyVarId = varId;
@@ -405,8 +405,8 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
         }
         // LFRic output files can come with separate edge mesh, still has
         // topology_dimension=2
-        else if ((varName == "Mesh2d_edge_half_levels" or
-                  varName == "Mesh2d_edge") and
+        else if ((varName == "Mesh2d_edge_half_levels" ||
+                  varName == "Mesh2d_edge") &&
                  this->GetAttInt(varId, "topology_dimension") == 2)
         {
           hasHalfLevelEdgeMesh = true;
@@ -414,7 +414,7 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
         }
         // Assume that mesh is half-level type otherwise (2D faces represent 3D volumes)
         // Adopt first mesh description
-        else if (mesh2D.meshTopologyVarId < 0 and
+        else if (mesh2D.meshTopologyVarId < 0 &&
                  this->GetAttInt(varId, "topology_dimension") == 2)
         {
           mesh2D.meshTopologyVarId = varId;
@@ -426,7 +426,7 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
   }
 
   // Must have at least one face mesh
-  if (mesh2D.meshTopologyVarId < 0 or mesh2D.numTopologies == 0)
+  if (mesh2D.meshTopologyVarId < 0 || mesh2D.numTopologies == 0)
   {
     std::cerr << "GetMesh2DDescription: At least one UGRID face mesh is required.\n";
     return UGRIDMeshDescription();
@@ -434,14 +434,14 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
 
   // Require that a multi-mesh file is an LFRic file - the current implementation
   // only supports a single UGRID mesh per file otherwise
-  if (not mesh2D.isLFRicXIOSFile and mesh2D.numTopologies > 1)
+  if (!mesh2D.isLFRicXIOSFile && mesh2D.numTopologies > 1)
   {
     std::cerr << "GetMesh2DDescription: Only LFRic output files can have multiple UGRID meshes.\n";
     return UGRIDMeshDescription();
   }
 
   // Accept up to 3 meshes in an LFRic file
-  if (mesh2D.isLFRicXIOSFile and mesh2D.numTopologies > 3)
+  if (mesh2D.isLFRicXIOSFile && mesh2D.numTopologies > 3)
   {
     std::cerr << "GetMesh2DDescription: LFRic output files can only have up to 3 UGRID meshes.\n";
     return UGRIDMeshDescription();
@@ -451,7 +451,7 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
   // Get node coordinate variables and their dimensions
   //
 
-  if (not this->VarHasAtt(mesh2D.meshTopologyVarId, "node_coordinates"))
+  if (!this->VarHasAtt(mesh2D.meshTopologyVarId, "node_coordinates"))
   {
     std::cerr << "GetMesh2DDescription: UGRID topology variable must have node_coordinates attribute.\n";
     return UGRIDMeshDescription();
@@ -468,15 +468,15 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
   }
 
   // Longitude must be the "x axis" to detect cubed-sphere grids
-  if (this->GetAttText(nodeCoordVarNames[0], "standard_name") == "latitude" or
+  if (this->GetAttText(nodeCoordVarNames[0], "standard_name") == "latitude" ||
       this->GetAttText(nodeCoordVarNames[0], "standard_name") == "projection_y_coordinate")
   {
     nodeCoordVarNames[0].swap(nodeCoordVarNames[1]);
   }
 
-  if ((this->GetAttText(nodeCoordVarNames[0], "standard_name") != "longitude" and
-       this->GetAttText(nodeCoordVarNames[0], "standard_name") != "projection_x_coordinate") or
-      (this->GetAttText(nodeCoordVarNames[1], "standard_name") != "latitude" and
+  if ((this->GetAttText(nodeCoordVarNames[0], "standard_name") != "longitude" &&
+       this->GetAttText(nodeCoordVarNames[0], "standard_name") != "projection_x_coordinate") ||
+      (this->GetAttText(nodeCoordVarNames[1], "standard_name") != "latitude" &&
        this->GetAttText(nodeCoordVarNames[1], "standard_name") != "projection_y_coordinate"))
   {
     std::cerr << "GetMesh2DDescription: Node coord variables must be named latitude/longitude " <<
@@ -501,7 +501,7 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
   // Get face-node connectivity variable and its dimensions
   //
 
-  if (not this->VarHasAtt(mesh2D.meshTopologyVarId, "face_node_connectivity"))
+  if (!this->VarHasAtt(mesh2D.meshTopologyVarId, "face_node_connectivity"))
   {
     std::cerr << "GetMesh2DDescription: UGRID topology variable must have face_node_connectivity attribute.\n";
     return UGRIDMeshDescription();
@@ -540,7 +540,7 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
 
   // Alternative face dimension ID for old LFRic output files, required
   // for identifying field variables
-  if (mesh2D.isLFRicXIOSFile and this->HasDim("nMesh2d_half_levels_face"))
+  if (mesh2D.isLFRicXIOSFile && this->HasDim("nMesh2d_half_levels_face"))
   {
     mesh2D.faceDimIdAlt = this->GetDimId("nMesh2d_half_levels_face");
   }
@@ -549,13 +549,13 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
   // Get edge coordinate variables and their dimensions (if available)
   //
 
-  if (hasHalfLevelEdgeMesh or this->VarHasAtt(mesh2D.meshTopologyVarId, "face_edge_connectivity"))
+  if (hasHalfLevelEdgeMesh || this->VarHasAtt(mesh2D.meshTopologyVarId, "face_edge_connectivity"))
   {
     // Prioritise half-level edge mesh if it exists - the face mesh may have face-edge connectivity, too,
     // but it will not be useable for edge-centered data if the meshes are not unified in LFRic output
     const int lookupMeshTopologyVarId = hasHalfLevelEdgeMesh ? meshTopologyVarEdgeId : mesh2D.meshTopologyVarId;
 
-    if (not this->VarHasAtt(lookupMeshTopologyVarId, "edge_coordinates"))
+    if (!this->VarHasAtt(lookupMeshTopologyVarId, "edge_coordinates"))
     {
       std::cerr << "GetMesh2DDescription: UGRID edge topology variable must have edge_coordinates attribute.\n";
       return UGRIDMeshDescription();
@@ -577,9 +577,9 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
       edgeCoordVarNames[0].swap(edgeCoordVarNames[1]);
     }
 
-  if ((this->GetAttText(edgeCoordVarNames[0], "standard_name") != "longitude" and
-       this->GetAttText(edgeCoordVarNames[0], "standard_name") != "projection_x_coordinate") or
-      (this->GetAttText(edgeCoordVarNames[1], "standard_name") != "latitude" and
+  if ((this->GetAttText(edgeCoordVarNames[0], "standard_name") != "longitude" &&
+       this->GetAttText(edgeCoordVarNames[0], "standard_name") != "projection_x_coordinate") ||
+      (this->GetAttText(edgeCoordVarNames[1], "standard_name") != "latitude" &&
        this->GetAttText(edgeCoordVarNames[1], "standard_name") != "projection_y_coordinate"))
     {
       std::cerr << "GetMesh2DDescription: Edge coord variables must be named latitude/longitude " <<
@@ -595,7 +595,7 @@ UGRIDMeshDescription netCDFLFRicFile::GetMesh2DDescription()
     mesh2D.numEdges = this->GetDimLen(mesh2D.edgeDimId);
 
     // Get face-edge connectivity if the mesh is unified
-    if (not hasHalfLevelEdgeMesh)
+    if (!hasHalfLevelEdgeMesh)
     {
       const std::string faceEdgeConnVar = this->GetAttText(mesh2D.meshTopologyVarId,
                                                            "face_edge_connectivity");
@@ -634,7 +634,7 @@ std::map<std::string, CFAxis> netCDFLFRicFile::GetZAxisDescription(const bool is
   // "half_levels" (cell mid-levels). We need to store these axes for accessing the data,
   // and create a third axis ("vtk") that counts the number vertical levels, for creating
   // the VTK grid.
-  if (isLFRicXIOSFile and (meshType == fullLevelFaceMesh or meshType == halfLevelFaceMesh))
+  if (isLFRicXIOSFile && (meshType == fullLevelFaceMesh || meshType == halfLevelFaceMesh))
   {
     if (this->HasVar("full_levels"))
     {
@@ -674,8 +674,8 @@ std::map<std::string, CFAxis> netCDFLFRicFile::GetZAxisDescription(const bool is
       {
         // Prefer to use level_height variable if it exists
         const std::string varName = this->GetVarName(varId);
-	if (varName == "level_height" or
-            (levels.axisVarId < 0 and varName == "model_level_number"))
+	if (varName == "level_height" ||
+            (levels.axisVarId < 0 && varName == "model_level_number"))
         {
           levels.axisVarId = varId;
           levels.axisDimId = this->GetVarDimId(levels.axisVarId, 0);
@@ -746,10 +746,10 @@ void netCDFLFRicFile::UpdateFieldMaps(const UGRIDMeshDescription & mesh2D,
 
     // Require these CF-netCDF attributes to distinguish fields from UGRID
     // variables and other data
-    bool valid = (this->VarHasAtt(varId, "standard_name") or
-                  this->VarHasAtt(varId, "long_name")) and
-                  this->VarHasAtt(varId, "mesh") and
-                  this->VarHasAtt(varId, "coordinates") and
+    bool valid = (this->VarHasAtt(varId, "standard_name") ||
+                  this->VarHasAtt(varId, "long_name")) &&
+                  this->VarHasAtt(varId, "mesh") &&
+                  this->VarHasAtt(varId, "coordinates") &&
                   this->VarHasAtt(varId, "location");
 
     // Identify and record variable dimensions, and add field to map if all
@@ -788,7 +788,7 @@ void netCDFLFRicFile::UpdateFieldMaps(const UGRIDMeshDescription & mesh2D,
           debugMacro("Found horizontal edge dim\n");
         }
         // Older LFRic files can have two different face meshes
-        else if (thisDimId == mesh2D.faceDimId or thisDimId == mesh2D.faceDimIdAlt)
+        else if (thisDimId == mesh2D.faceDimId || thisDimId == mesh2D.faceDimIdAlt)
         {
           fieldSpec.hasHorizontalDim = true;
           // Assume half-level faces for now, if meshType has not been determined yet
@@ -797,7 +797,7 @@ void netCDFLFRicFile::UpdateFieldMaps(const UGRIDMeshDescription & mesh2D,
           isIdentified = true;
           debugMacro("Found horizontal face dim\n");
         }
-        else if (thisDimId == fullLevelsDimId or thisDimId == halfLevelsDimId)
+        else if (thisDimId == fullLevelsDimId || thisDimId == halfLevelsDimId)
         {
           fieldSpec.hasVerticalDim = true;
           // Only face-type fields can be defined at full level (cell interfaces)
@@ -815,7 +815,7 @@ void netCDFLFRicFile::UpdateFieldMaps(const UGRIDMeshDescription & mesh2D,
         }
         // If dimension is not known, assume it is a component dimension if it
         // has up to 9 components and no other component dimension has been set
-        else if (this->GetDimLen(thisDimId) < 10 and not fieldSpec.hasComponentDim)
+        else if (this->GetDimLen(thisDimId) < 10 && !fieldSpec.hasComponentDim)
         {
           fieldSpec.hasComponentDim = true;
           fieldSpec.dims[iDim].dimType = componentAxisDim;
@@ -867,7 +867,7 @@ void netCDFLFRicFile::UpdateFieldMaps(const UGRIDMeshDescription & mesh2D,
         }
         // Make all fields available as cell data
         // W2 fields require face-edge connectivity data
-        if (fieldSpec.meshType != halfLevelEdgeMesh or mesh2D.faceEdgeConnVarId > -1)
+        if (fieldSpec.meshType != halfLevelEdgeMesh || mesh2D.faceEdgeConnVarId > -1)
         {
           fieldSpec.location = cellFieldLoc;
           std::map<std::string, DataField>::const_iterator it = CellFields.find(varName);

--- a/src/cxx/Plugin/Reader/netCDFLFRicFile.h
+++ b/src/cxx/Plugin/Reader/netCDFLFRicFile.h
@@ -12,6 +12,12 @@
 #include <string>
 #include <map>
 
+// MSVC compiler requires explicit symbol import/export for DLLs
+// Use mechanism provided by VTK/ParaView build system to handle
+// this automatically
+#include "vtkNetCDFLFRicReaderModule.h"
+#define NETCDFLFRICFILE_EXPORT VTKNETCDFLFRICREADER_EXPORT
+
 // LFRic 2D mesh types
 enum mesh2DTypes {unknownMesh, halfLevelEdgeMesh, halfLevelFaceMesh, fullLevelFaceMesh};
 
@@ -128,94 +134,94 @@ public:
    * The file is opened on construction and will be closed by the
    * destructor.
    */
-  netCDFLFRicFile(const char* fileName);
-  ~netCDFLFRicFile();
+  NETCDFLFRICFILE_EXPORT netCDFLFRicFile(const char* fileName);
+  NETCDFLFRICFILE_EXPORT ~netCDFLFRicFile();
 
   /**
    * Check if the class constructor managed to open the netCDF file.
    */
-  bool IsFileOpen();
+  NETCDFLFRICFILE_EXPORT bool IsFileOpen();
 
   /**
    * Return name of the netCDF file.
    */
-  const char* GetFileName();
+  NETCDFLFRICFILE_EXPORT const char* GetFileName();
 
   /**
    * Check if netCDF dimension dimName exists.
    */
-  bool HasDim(const std::string& dimName);
+  NETCDFLFRICFILE_EXPORT bool HasDim(const std::string& dimName);
 
   /**
    * Return length of netCDF dimension with ID dimId.
    */
-  size_t GetDimLen(const int dimId);
+  NETCDFLFRICFILE_EXPORT size_t GetDimLen(const int dimId);
 
   /**
    * Return netCDF dimension ID for dimension dimName.
    */
-  int GetDimId(const std::string& dimName);
+  NETCDFLFRICFILE_EXPORT int GetDimId(const std::string& dimName);
 
   /**
    * Return netCDF dimension name for ID dimId.
    */
-  std::string GetDimName(const int dimId);
+  NETCDFLFRICFILE_EXPORT std::string GetDimName(const int dimId);
 
   /**
    * Return netCDF variable ID for variable varName.
    */
-  int GetVarId(const std::string& varName);
+  NETCDFLFRICFILE_EXPORT int GetVarId(const std::string& varName);
 
   /**
    * Return netCDF variable name for ID varID.
    */
-  std::string GetVarName(const int varId);
+  NETCDFLFRICFILE_EXPORT std::string GetVarName(const int varId);
 
   /**
    * Return the number of dimensions for netCDF variable with ID varId.
    */
-  size_t GetVarNumDims(const int varId);
+  NETCDFLFRICFILE_EXPORT size_t GetVarNumDims(const int varId);
 
   /**
    * Return ID of the dimth dimension of netCDF variable with ID varId.
    */
-  int GetVarDimId(const int varId, const size_t dim);
+  NETCDFLFRICFILE_EXPORT int GetVarDimId(const int varId, const size_t dim);
 
   /**
    * Return integer attribute attName of netCDF variable with ID varId.
    */
-  int GetAttInt(const int varId, const std::string& attName);
+  NETCDFLFRICFILE_EXPORT int GetAttInt(const int varId, const std::string& attName);
 
   ///@{
   /**
    * Return string attribute attName of netCDF variable with ID varId
    * or name varName.
    */
-  std::string GetAttText(const int varId, const std::string& attName);
-  std::string GetAttText(const std::string& varName, const std::string& attName);
+  NETCDFLFRICFILE_EXPORT std::string GetAttText(const int varId, const std::string& attName);
+  NETCDFLFRICFILE_EXPORT std::string GetAttText(const std::string& varName, const std::string& attName);
   ///@}
 
   /**
    * Return string attribute attName of netCDF variable with ID varId
    * split into a vector of strings.
    */
-  std::vector<std::string> GetAttTextSplit(const int varId,
-                                           const std::string& attName);
+  NETCDFLFRICFILE_EXPORT std::vector<std::string> GetAttTextSplit(const int varId,
+                                                                  const std::string& attName);
 
   /**
    * Check if netCDF variable varName exists.
    */
-  bool HasVar(const std::string& varName);
+  NETCDFLFRICFILE_EXPORT bool HasVar(const std::string& varName);
 
   /**
    * Check if netCDF variable with ID varId has attribute attName.
    */
-  bool VarHasAtt(const int varId, const std::string& attName);
+  NETCDFLFRICFILE_EXPORT bool VarHasAtt(const int varId, const std::string& attName);
 
   /**
    * Return the total number of netCDF variables in the file.
    */
-  size_t GetNumVars();
+  NETCDFLFRICFILE_EXPORT size_t GetNumVars();
 
   /**
    * Load data for double precision netCDF variable with ID varId
@@ -225,10 +231,10 @@ public:
    * @note Make sure that buffer is sufficiently larget to hold the
    * data!
    */
-  void LoadVarDouble(const int varId,
-                     const std::vector<size_t>& start,
-                     const std::vector<size_t>& count,
-                     double* buffer);
+  NETCDFLFRICFILE_EXPORT void LoadVarDouble(const int varId,
+                                            const std::vector<size_t>& start,
+                                            const std::vector<size_t>& count,
+                                            double* buffer);
 
   ///@{
   /**
@@ -236,27 +242,27 @@ public:
    * netCDF variable with ID varID, using vectors start and count
    * for subsetting.
    */
-  std::vector<double> GetVarDouble(const int varId,
-                                   const std::vector<size_t>& start,
-                                   const std::vector<size_t>& count);
+  NETCDFLFRICFILE_EXPORT std::vector<double> GetVarDouble(const int varId,
+                                                          const std::vector<size_t>& start,
+                                                          const std::vector<size_t>& count);
 
-  std::vector<long long> GetVarLongLong(const int varId,
-                                        const std::vector<size_t>& start,
-                                        const std::vector<size_t>& count);
+  NETCDFLFRICFILE_EXPORT std::vector<long long> GetVarLongLong(const int varId,
+                                                               const std::vector<size_t>& start,
+                                                               const std::vector<size_t>& count);
   ///@}
 
-  UGRIDMeshDescription GetMesh2DDescription();
+  NETCDFLFRICFILE_EXPORT UGRIDMeshDescription GetMesh2DDescription();
 
-  std::map<std::string, CFAxis> GetZAxisDescription(const bool isLFRicXIOSFile,
-                                                    const mesh2DTypes meshType);
+  NETCDFLFRICFILE_EXPORT std::map<std::string, CFAxis> GetZAxisDescription(const bool isLFRicXIOSFile,
+                                                                           const mesh2DTypes meshType);
 
-  CFAxis GetTAxisDescription();
+  NETCDFLFRICFILE_EXPORT CFAxis GetTAxisDescription();
 
-  void UpdateFieldMaps(const UGRIDMeshDescription & mesh2D,
-                       const std::map<std::string, CFAxis> & zAxes,
-                       const CFAxis & tAxis,
-                       std::map<std::string, DataField> & CellFields,
-                       std::map<std::string, DataField> & PointFields);
+  NETCDFLFRICFILE_EXPORT void UpdateFieldMaps(const UGRIDMeshDescription & mesh2D,
+                                              const std::map<std::string, CFAxis> & zAxes,
+                                              const CFAxis & tAxis,
+                                              std::map<std::string, DataField> & CellFields,
+                                              std::map<std::string, DataField> & PointFields);
 
 private:
 

--- a/src/cxx/Plugin/Reader/netCDFLFRicReaderUtils.cxx
+++ b/src/cxx/Plugin/Reader/netCDFLFRicReaderUtils.cxx
@@ -164,7 +164,7 @@ void resolvePeriodicGrid(std::vector<double> & nodeCoordsLon,
   if (globalModel)
   {
     // Assume cubed-sphere grid with range (newer output files use -180..180 degrees)
-    if (lonMin >= -180.0 and lonMax <= 180.0)
+    if (lonMin >= -180.0 && lonMax <= 180.0)
     {
       lonOffset = 0.0;
       latOffset = 0.0;
@@ -173,7 +173,7 @@ void resolvePeriodicGrid(std::vector<double> & nodeCoordsLon,
       debugMacro("resolvePeriodicGrid: Assuming cubed-sphere grid with -180..180 lon range, setting lonOffset=" <<
                  lonOffset << " latOffset=" << latOffset << endl);
     }
-    else if (lonMin >= 0.0 and lonMax <= 360.0)
+    else if (lonMin >= 0.0 && lonMax <= 360.0)
     {
       lonOffset = 180.0;
       latOffset = 0.0;
@@ -241,7 +241,7 @@ void resolvePeriodicGrid(std::vector<double> & nodeCoordsLon,
 
     // If face spans across, loop over vertices (nodes) and mirror
     // nodes at the left boundary to resolve grid periodicity
-    if (spanLon or spanLat)
+    if (spanLon || spanLat)
     {
       for (size_t iVertex = 0; iVertex < numVertsPerFace; iVertex++)
       {
@@ -252,7 +252,7 @@ void resolvePeriodicGrid(std::vector<double> & nodeCoordsLon,
         const double nodeCoordsOffsetLat = nodeCoordsLat[nodeId] - latOffset;
 
         // Mirror corner nodes
-        if (spanLon and spanLat and nodeCoordsOffsetLon < 0 and nodeCoordsOffsetLat < 0)
+        if (spanLon && spanLat && nodeCoordsOffsetLon < 0 && nodeCoordsOffsetLat < 0)
         {
           // Keep track of mirrored node to avoid degeneracy; insert a new node if
           // no mirror node has been created yet
@@ -273,8 +273,8 @@ void resolvePeriodicGrid(std::vector<double> & nodeCoordsLon,
           }
         }
         // Mirror nodes on left or right domain boundary
-        else if (spanLon and ((nodeCoordsOffsetLon < 0 and mirrorFromWest) or \
-                              (nodeCoordsOffsetLon > 0 and not mirrorFromWest)))
+        else if (spanLon && ((nodeCoordsOffsetLon < 0 && mirrorFromWest) || \
+                             (nodeCoordsOffsetLon > 0 && !mirrorFromWest)))
         {
           mirrorNodesIt = mirrorNodesLon.find(nodeId);
           if (mirrorNodesIt == mirrorNodesLon.end())
@@ -291,7 +291,7 @@ void resolvePeriodicGrid(std::vector<double> & nodeCoordsLon,
           }
         }
         // Mirror nodes on bottom domain boundary
-        else if (spanLat and nodeCoordsOffsetLat < 0)
+        else if (spanLat && nodeCoordsOffsetLat < 0)
         {
           mirrorNodesIt = mirrorNodesLat.find(nodeId);
           if (mirrorNodesIt == mirrorNodesLat.end())
@@ -350,7 +350,7 @@ void prepareGrid(std::vector<double> & nodeCoordsX,
   // Detect and possibly resolve gap in longitudes for non-planar-LAMs that cross the dateline
   //
 
-  if (not isPlanarLAM)
+  if (!isPlanarLAM)
   {
     const double lonGapSizeThreshold = 30.0;
     resolveLongitudeGap(nodeCoordsX, xMin, xMax, lonGapSizeThreshold);
@@ -362,7 +362,7 @@ void prepareGrid(std::vector<double> & nodeCoordsX,
 
   double solidAngle = 0.0;
   bool hasWrapAroundCells = false;
-  if (not isPlanarLAM)
+  if (!isPlanarLAM)
   {
     if (computeSolidAngle(nodeCoordsX, nodeCoordsY, faceNodeConnectivity,
                           numFaces, numVertsPerFace, solidAngle, hasWrapAroundCells))
@@ -374,7 +374,7 @@ void prepareGrid(std::vector<double> & nodeCoordsX,
 
   const double solidAngleThreshold = 3.0*vtkMath::Pi();
   bool globalModel = false;
-  if (solidAngle > solidAngleThreshold and not isPlanarLAM)
+  if (!isPlanarLAM && solidAngle > solidAngleThreshold)
   {
     globalModel = true;
     debugMacro("prepareGrid: Assuming mesh is global." << endl);
@@ -385,7 +385,7 @@ void prepareGrid(std::vector<double> & nodeCoordsX,
   }
 
   // computeSolidAngle scans for wrap-around cells, but is only executed when isPlanarLAM == false
-  if (hasWrapAroundCells or isPlanarLAM)
+  if (hasWrapAroundCells || isPlanarLAM)
   {
     resolvePeriodicGrid(nodeCoordsX, nodeCoordsY, faceNodeConnectivity,
                         numFaces, numVertsPerFace, globalModel, yMin,

--- a/src/cxx/Plugin/Reader/netCDFLFRicReaderUtils.h
+++ b/src/cxx/Plugin/Reader/netCDFLFRicReaderUtils.h
@@ -4,8 +4,13 @@
 #include <vtkMath.h>
 #include <vtkAssume.h>
 #include <vtkDataArrayAccessor.h>
-
 #include <vector>
+
+// MSVC compiler requires explicit symbol import/export for DLLs
+// Use mechanism provided by VTK/ParaView build system to handle
+// this automatically
+#include "vtkNetCDFLFRicReaderModule.h"
+#define LFRICREADERUTILS_EXPORT VTKNETCDFLFRICREADER_EXPORT
 
 // Functor for setting a vtkDataArray with point coordinates
 // in layer-first ordering
@@ -79,29 +84,29 @@ private:
   const bool cartCoords;
 };
 
-void resolveLongitudeGap(std::vector<double> & nodeCoordsLon,
-                         const double lonMin,
-                         const double lonMax,
-                         const double lonGapSizeThreshold);
+LFRICREADERUTILS_EXPORT void resolveLongitudeGap(std::vector<double> & nodeCoordsLon,
+                                                 const double lonMin,
+                                                 const double lonMax,
+                                                 const double lonGapSizeThreshold);
 
-int computeSolidAngle(const std::vector<double> & nodeCoordsLon,
-                      const std::vector<double> & nodeCoordsLat,
-                      const std::vector<long long> & faceNodeConnectivity,
-                      const size_t numFaces,
-                      const size_t numVertsPerFace,
-                      double & solidAngle,
-                      bool & hasWrapAroundCells);
+LFRICREADERUTILS_EXPORT int computeSolidAngle(const std::vector<double> & nodeCoordsLon,
+                                              const std::vector<double> & nodeCoordsLat,
+                                              const std::vector<long long> & faceNodeConnectivity,
+                                              const size_t numFaces,
+                                              const size_t numVertsPerFace,
+                                              double & solidAngle,
+                                              bool & hasWrapAroundCells);
 
-void resolvePeriodicGrid(std::vector<double> & nodeCoordsX,
-                         std::vector<double> & nodeCoordsY,
-                         std::vector<long long> & faceNodeConnectivity,
-                         const size_t numFaces,
-                         const size_t numVertsPerFace,
-                         const bool globalModel,
-                         const double latMin,
-                         const double latMax,
-                         const double lonMin,
-                         const double lonMax);
+LFRICREADERUTILS_EXPORT void resolvePeriodicGrid(std::vector<double> & nodeCoordsX,
+                                                 std::vector<double> & nodeCoordsY,
+                                                 std::vector<long long> & faceNodeConnectivity,
+                                                 const size_t numFaces,
+                                                 const size_t numVertsPerFace,
+                                                 const bool globalModel,
+                                                 const double latMin,
+                                                 const double latMax,
+                                                 const double lonMin,
+                                                 const double lonMax);
 
 void prepareGrid(std::vector<double> & nodeCoordsX,
                  std::vector<double> & nodeCoordsY,

--- a/src/cxx/Plugin/Reader/test/CMakeLists.txt
+++ b/src/cxx/Plugin/Reader/test/CMakeLists.txt
@@ -7,7 +7,8 @@ set(Test_SRCS catch_main.cxx generate_testfile.cxx vtkNetCDFLFRicReaderUnitTest.
     netCDFLFRicFileUnitTest.cxx netCDFLFRicReaderUtilsUnitTest.cxx)
 
 add_executable (netCDFLFRicReader_tests ${Test_SRCS})
-target_include_directories(netCDFLFRicReader_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+# Include auto-generated header file for DLL symbol import/export when compiling with MSVC
+target_include_directories(netCDFLFRicReader_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_BINARY_DIR}/..)
 
 if (ParaView_VERSION GREATER_EQUAL 5.7)
 
@@ -15,6 +16,11 @@ if (ParaView_VERSION GREATER_EQUAL 5.7)
   # need to build additional shared library for testing
   set(lib_SRCS ../vtkNetCDFLFRicReader.cxx ../netCDFLFRicFile.cxx ../netCDFLFRicReaderUtils.cxx)
   add_library(netCDFLFRicReaderShared ${lib_SRCS})
+  # Include auto-generated header file for DLL symbol import/export when compiling with MSVC
+  # and request symbol export
+  target_include_directories(netCDFLFRicReaderShared PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
+  target_compile_definitions(netCDFLFRicReaderShared PRIVATE vtkNetCDFLFRicReader_EXPORTS)
+
   target_link_libraries(netCDFLFRicReaderShared PRIVATE
     VTK::netcdf
     VTK::CommonCore

--- a/src/cxx/Plugin/Reader/test/netCDFLFRicFileUnitTest.cxx
+++ b/src/cxx/Plugin/Reader/test/netCDFLFRicFileUnitTest.cxx
@@ -154,6 +154,22 @@ TEST_CASE( "NetCDF Data Tests", "[data]" )
 {
   netCDFLFRicFile ncFile("testdata_single_mesh_valid.nc");
 
+  SECTION( "LoadVarDouble Returns Correct Result" )
+  {
+    const int varId = ncFile.GetVarId("var2");
+    std::vector<double> result({-1.0});
+    ncFile.LoadVarDouble(varId, {0,0}, {1,1}, result.data());
+    REQUIRE( result[0] == Approx(0.0) );
+  }
+
+  SECTION( "LoadVarDouble Does Not Modify Buffer With Incorrect Number Of Dims" )
+  {
+    const int varId = ncFile.GetVarId("var2");
+    std::vector<double> result({-1.0});
+    ncFile.LoadVarDouble(varId, {0}, {1}, result.data());
+    REQUIRE( result[0] == Approx(-1.0) );
+  }
+
   SECTION( "GetVarDouble Returns Correct Result" )
   {
     const int varId = ncFile.GetVarId("var2");

--- a/src/cxx/Plugin/Reader/test/netCDFLFRicReaderUtilsUnitTest.cxx
+++ b/src/cxx/Plugin/Reader/test/netCDFLFRicReaderUtilsUnitTest.cxx
@@ -80,7 +80,7 @@ TEST_CASE( "ComputeSolidAngle Test", "[basic]" )
     REQUIRE( computeSolidAngle(lon, lat, faceNodeConnectivity, numFaces,
 			       numVertsPerFace, solidAngle, hasWrapAroundCell) );
     REQUIRE( solidAngle == Approx(0.0) );
-    REQUIRE( not hasWrapAroundCell );
+    REQUIRE( !hasWrapAroundCell );
   }
 
   SECTION( "Correct Results for Single Global Cell" )
@@ -94,10 +94,10 @@ TEST_CASE( "ComputeSolidAngle Test", "[basic]" )
     double solidAngle = -1.0;
     bool hasWrapAroundCell = true;
     
-    REQUIRE( not computeSolidAngle(lon, lat, faceNodeConnectivity, numFaces,
+    REQUIRE( !computeSolidAngle(lon, lat, faceNodeConnectivity, numFaces,
 			           numVertsPerFace, solidAngle, hasWrapAroundCell) );
     REQUIRE( solidAngle == Approx(4.0*vtkMath::Pi()) );
-    REQUIRE( not hasWrapAroundCell );
+    REQUIRE( !hasWrapAroundCell );
   }
 
   SECTION( "Correct Results for Global Model With Wrap-Around Cells" )
@@ -112,7 +112,7 @@ TEST_CASE( "ComputeSolidAngle Test", "[basic]" )
     double solidAngle = -1.0;
     bool hasWrapAroundCell = true;
     
-    REQUIRE( not computeSolidAngle(lon, lat, faceNodeConnectivity, numFaces,
+    REQUIRE( !computeSolidAngle(lon, lat, faceNodeConnectivity, numFaces,
 			           numVertsPerFace, solidAngle, hasWrapAroundCell) );
 
     // Compute gap left by the wrap-around cell

--- a/src/cxx/Plugin/Reader/vtkNetCDFLFRicReader.h
+++ b/src/cxx/Plugin/Reader/vtkNetCDFLFRicReader.h
@@ -10,19 +10,19 @@
 #ifndef vtkNetCDFLFRicReader_h
 #define vtkNetCDFLFRicReader_h
 
-#include "netCDFLFRicFile.h"
-
-#include <vtkIONetCDFModule.h> // For export macro
+#include "vtkNetCDFLFRicReaderModule.h" // For export macro
 #include <vtkUnstructuredGridAlgorithm.h>
 #include <vtkUnstructuredGrid.h>
 #include <vtkSmartPointer.h>
 #include <vtk_netcdf.h>
 
+#include "netCDFLFRicFile.h"
+
 #include <vector>
 #include <map>
 #include <string>
 
-class VTKIONETCDF_EXPORT vtkNetCDFLFRicReader : public vtkUnstructuredGridAlgorithm
+class VTKNETCDFLFRICREADER_EXPORT vtkNetCDFLFRicReader : public vtkUnstructuredGridAlgorithm
 {
 
 public:


### PR DESCRIPTION
C++ source code modifications to enable Microsoft Visual C++ builds on Windows, resolving #9:
- Replace keyword-like forms of logical operators (which are not supported by the default MSVC configuration) with symbol-like forms
- Additional explicit static casts to resolve compiler warnings
- Use automated handling of MSVC symbol import/export for DLLs provided by the VTK/ParaView build system

Also add missing unit tests for `LoadVarDouble` method.