### PR TITLE
Fix version comparison issue

### DIFF
--- a/src/cxx/CMakeLists.txt
+++ b/src/cxx/CMakeLists.txt
@@ -12,7 +12,7 @@ include(CTest)
 # Locate ParaView build and import CMake config, macros etc.
 FIND_PACKAGE(ParaView REQUIRED)
 
-if (ParaView_VERSION GREATER_EQUAL 5.7)
+if (ParaView_VERSION VERSION_GREATER_EQUAL 5.7)
 
   # New build system
   include(GNUInstallDirs)

--- a/src/cxx/Plugin/Reader/CMakeLists.txt
+++ b/src/cxx/Plugin/Reader/CMakeLists.txt
@@ -11,7 +11,7 @@ set(smsrcs vtkNetCDFLFRicReader.cxx)
 set(srcs netCDFLFRicFile.cxx netCDFLFRicReaderUtils.cxx)
 set(hdrs vtkNetCDFLFRicReader.h netCDFLFRicFile.h netCDFLFRicReaderUtils.h)
 
-if (ParaView_VERSION GREATER_EQUAL 5.7)
+if (ParaView_VERSION VERSION_GREATER_EQUAL 5.7)
 
   # New way of building plugins - tell CMake to build VTK module
   vtk_module_add_module(vtkNetCDFLFRicReader

--- a/src/cxx/Plugin/Reader/test/CMakeLists.txt
+++ b/src/cxx/Plugin/Reader/test/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable (netCDFLFRicReader_tests ${Test_SRCS})
 # Include auto-generated header file for DLL symbol import/export when compiling with MSVC
 target_include_directories(netCDFLFRicReader_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_BINARY_DIR}/..)
 
-if (ParaView_VERSION GREATER_EQUAL 5.7)
+if (ParaView_VERSION VERSION_GREATER_EQUAL 5.7)
 
   # New build system creates module libraries which cannot be linked,
   # need to build additional shared library for testing


### PR DESCRIPTION
Use CMake's `VERSION_GREATER_EQUAL` instead of `GREATER_EQUAL` to ensure that `5.10.0 >= 5.7` evaluates to `true`, addressing #11.