### PR TITLE
13 resolve mesh handling issues

### DIFF
--- a/src/cxx/Plugin/Reader/netCDFLFRicReaderUtils.cxx
+++ b/src/cxx/Plugin/Reader/netCDFLFRicReaderUtils.cxx
@@ -99,8 +99,9 @@ int computeSolidAngle(const std::vector<double> & nodeCoordsLon,
   }
 
   // Traverse grid and compute total solid angle of the horizontal domain on the sphere
-  double lon[numVertsPerFace];
-  double lat[numVertsPerFace];
+  // Need to use constant array length here for C++ standard compliance
+  double lon[4];
+  double lat[4];
   const double deg2rad = vtkMath::Pi()/180.0;
   for (size_t iFace = 0; iFace < numFaces; iFace++)
   {

--- a/src/cxx/Plugin/Reader/netCDFLFRicReaderUtils.h
+++ b/src/cxx/Plugin/Reader/netCDFLFRicReaderUtils.h
@@ -97,6 +97,14 @@ LFRICREADERUTILS_EXPORT int computeSolidAngle(const std::vector<double> & nodeCo
                                               double & solidAngle,
                                               bool & hasWrapAroundCells);
 
+LFRICREADERUTILS_EXPORT int computeEdgeLength(const std::vector<double> & nodeCoordsX,
+                                              const std::vector<double> & nodeCoordsY,
+                                              const std::vector<long long> & faceNodeConnectivity,
+                                              const size_t numFaces,
+                                              const size_t numVertsPerFace,
+                                              double & edgeLengthX,
+                                              double & edgeLengthY);
+
 LFRICREADERUTILS_EXPORT void resolvePeriodicGrid(std::vector<double> & nodeCoordsX,
                                                  std::vector<double> & nodeCoordsY,
                                                  std::vector<long long> & faceNodeConnectivity,

--- a/src/cxx/Plugin/Reader/vtkNetCDFLFRicReader.cxx
+++ b/src/cxx/Plugin/Reader/vtkNetCDFLFRicReader.cxx
@@ -334,7 +334,7 @@ int vtkNetCDFLFRicReader::RequestData(vtkInformation *vtkNotUsed(request),
     }
   }
   // VTK points only for W2 visualisation
-  else if (this->OutputMode == 1 && this->mesh2D.edgeDimId >= 0)
+  else if (this->OutputMode == 1 && this->mesh2D.edgeCoordXVarId >= 0)
   {
     if (!this->CreateVTKPoints(inputFile, outputGrid,
                                static_cast<size_t>(startLevel),


### PR DESCRIPTION
Fix various mesh handling issues, resolving #13:
* Reader accepts LFRic mesh generator UGRID files
* Wrap-around cells in biperiodic grids are now visible
* Global (cubed-sphere) mesh periodicity is now correctly resolved if dateline vertices are on the Western boundary

This PR also increases the threshold for accepting an unknown netCDF dimension as a variable component dimension, as some output files have variables with a larger number of components.